### PR TITLE
Add consolidated Willow Lab reference documents

### DIFF
--- a/MATH_COMPILATION.md
+++ b/MATH_COMPILATION.md
@@ -1,0 +1,17 @@
+# Willow Lab Mathematical Constructs
+
+## Step-1 invariants and topology batteries
+- **Spectral vs. entanglement temperature duality**: the Spectral test computes the inverse curvature of the log-resolvent trace and compares it against the inverse slope of the entanglement entropy–energy curve near the JT≈1 window, enforcing a unit-slope, high-R² regression to certify the duality.【F:Willow lab setup.txt†L1182-L1276】
+- **η-lock fault-tolerance signatures**: sliding windows demand consistent sign in η oscillations and frozen Chern parity, while spectral-flow crossings seed decoder priors that bias between parity and phase flips.【F:Willow lab setup.txt†L1285-L1347】
+- **Wilson-loop geometry and residue atlas**: non-Abelian loops stack overlap matrices via SVD-aligned transport to report Abelian phases, eigenvalue spectra, and curvature logs; residues emerge from adjugate traces of (I−U) at near-zero eigenvalues to expose poles.【F:Willow lab setup.txt†L1364-L1448】
+- **Nested T¹⁴ loops and black-hole potential**: seven-layer Kronecker stacking of Wilson curvatures yields a c₁₄ integer estimator, and residue-weighted 1/r² superposition builds the “black-hole” potential map across parameter grids.【F:Willow lab setup.txt†L1480-L1558】
+
+## Parameter-space cartography analytics
+- **Planned computations**: the cartography module scans two-control grids, extracts (I−U) poles and residues via the adjugate trick, sums gravitational potentials Φ(λ)=∑α |Rα|/(‖λ−λα‖ᵖ+ε) with p≈2, differentiates the phase field W=∇arg Tr(I−U)⁻¹, diagnoses EPs through det-winding, eigenvector conditioning, and branch-point tests, and finds saddles from Φ’s Hessian before feeding T¹⁴ workflows.【F:Willow lab ext 1.txt†L2-L178】
+- **Residue-driven fields**: `black_hole_potential` discretely superposes high-residue sources, defaulting to the top 5% unless a custom mask is provided, while `phase_wind_field` gradients the argument of the resolvent trace to expose circulation of topological charge.【F:Willow lab ext 1.txt†L623-L758】
+- **Determinant winding and saddles**: plaquette det-winding unwraps det(I−U) phases over 1×1 loops to accumulate 2π-normalized winding counts, and `hessian_saddles` tests the sign of Φ’s Hessian eigenvalues to isolate saddle basins.【F:Willow lab ext 1.txt†L760-L945】
+- **Cancellation-safe resolvent magnitude**: reuse of the Step-1 surrogate switches between |1/(1−λ)| off the unit circle and 1/(2|sin(θ/2)|) on it, summing per grid point to avoid catastrophic cancellation.【F:Willow lab ext 1.txt†L947-L1018】
+- **Exceptional-point candidates**: det-winding masks combine with large eigenvector condition numbers to flag EP plaquettes, creating a boolean lattice ready for contouring and downstream Wilson paths.【F:Willow lab ext 1.txt†L1020-L1069】
+
+## Scaling notes
+- The naive Φ superposition is O((NₓN_y)²); production guidance recommends truncating to the top residues, applying FFT-based Poisson solves for p=2 lattices, or tiling with halo blending to parallelize large parameter scans.【F:Willow lab ext 1.txt†L1570-L1628】

--- a/MATH_COMPILATION.md
+++ b/MATH_COMPILATION.md
@@ -7,7 +7,14 @@
 - **Nested T¹⁴ loops and black-hole potential**: seven-layer Kronecker stacking of Wilson curvatures yields a c₁₄ integer estimator, and residue-weighted 1/r² superposition builds the “black-hole” potential map across parameter grids.【F:Willow lab setup.txt†L1480-L1558】
 
 ## Parameter-space cartography analytics
-- **Planned computations**: the cartography module scans two-control grids, extracts (I−U) poles and residues via the adjugate trick, sums gravitational potentials Φ(λ)=∑α |Rα|/(‖λ−λα‖ᵖ+ε) with p≈2, differentiates the phase field W=∇arg Tr(I−U)⁻¹, diagnoses EPs through det-winding, eigenvector conditioning, and branch-point tests, and finds saddles from Φ’s Hessian before feeding T¹⁴ workflows.【F:Willow lab ext 1.txt†L2-L178】
+- **Planned computations**:
+  - The cartography module scans two-control grids.
+  - It extracts (I−U) poles and residues via the adjugate trick.
+  - It sums gravitational potentials: Φ(λ)=∑α |Rα|/(‖λ−λα‖ᵖ+ε) with p≈2.
+  - It differentiates the phase field: W=∇arg Tr(I−U)⁻¹.
+  - It diagnoses exceptional points (EPs) through det-winding, eigenvector conditioning, and branch-point tests.
+  - It finds saddles from Φ’s Hessian before feeding T¹⁴ workflows.
+  - 【F:Willow lab ext 1.txt†L2-L178】
 - **Residue-driven fields**: `black_hole_potential` discretely superposes high-residue sources, defaulting to the top 5% unless a custom mask is provided, while `phase_wind_field` gradients the argument of the resolvent trace to expose circulation of topological charge.【F:Willow lab ext 1.txt†L623-L758】
 - **Determinant winding and saddles**: plaquette det-winding unwraps det(I−U) phases over 1×1 loops to accumulate 2π-normalized winding counts, and `hessian_saddles` tests the sign of Φ’s Hessian eigenvalues to isolate saddle basins.【F:Willow lab ext 1.txt†L760-L945】
 - **Cancellation-safe resolvent magnitude**: reuse of the Step-1 surrogate switches between |1/(1−λ)| off the unit circle and 1/(2|sin(θ/2)|) on it, summing per grid point to avoid catastrophic cancellation.【F:Willow lab ext 1.txt†L947-L1018】

--- a/MODULE_TRICKS.md
+++ b/MODULE_TRICKS.md
@@ -11,7 +11,7 @@
 - The CLI loader hydrates a Willow bundle, runs the Step-1 Trinity invariants (`WillowTrinityStep1.compute_all`) with configurable JT anchor and window, conditionally executes Spectral duality, η-lock, and geometry batteries when data is present, and records JSON summaries to an artifacts directory.【F:Willow lab setup.txt†L1600-L1718】
 
 ## Zip-to-Willow conveyor
-- Stage A triage inspects zip members by magic bytes, records a manifest, and opportunistically lifts JT grids or eigenpairs, while Stage B extractors reconcile partial payloads into complete Willow bundles before normalization and persistence to hashed `.npz`/`.h5` artifacts with provenance manifests.【F:Willow lab Injest.txt†L1-L200】【F:Willow lab Injest.txt†L520-L678】
+- Stage A triage inspects zip members by magic bytes, records a manifest, and opportunistically lifts JT grids or eigenpairs, while Stage B extractors reconcile partial payloads into complete Willow bundles before normalization and persistence to hashed `.npz`/`.h5` artifacts with provenance manifests.【F:Willow lab Ingest.txt†L1-L200】【F:Willow lab Ingest.txt†L520-L678】
 
 ## Incremental caching and HDF5 probing
 - `DirCache` tracks size/mtime and SHA256 digests per ingestion root to skip unchanged files, and the one-level HDF5 walker samples root and child groups within memory budgets so foreign layouts still surface key tensors.【F:Willow lab Helpers.txt†L1-L520】

--- a/MODULE_TRICKS.md
+++ b/MODULE_TRICKS.md
@@ -1,7 +1,8 @@
 # Willow Lab Module Integration & Operational Tricks
 
 ## Project skeleton and environment
-- Standardize on a reproducible Conda stack (Python 3.11 plus NumPy, SciPy, pandas, h5py, numba, PyYAML, Matplotlib, NetworkX, pytest) and organize the repository so ingestion, caching, Trinity analysis, tests, geometry, T¹⁴ logic, and CLI live in predictable modules under `willowlab/` with YAML configs for orchestration.【F:Willow lab setup.txt†L205-L324】
+- Standardize on a reproducible Conda stack (Python 3.11 plus NumPy, SciPy, pandas, h5py, numba, PyYAML, Matplotlib, NetworkX, pytest).【F:Willow lab setup.txt†L205-L324】
+- Organize the repository so ingestion, caching, Trinity analysis, tests, geometry, T¹⁴ logic, and CLI live in predictable modules under `willowlab/` with YAML configs for orchestration.
 
 ## Schema-driven ingestion core
 - The immutable `WillowDataset` dataclass unifies JT scan points, Floquet eigen-data, resolvent traces, entropy, η oscillations, Chern parity, spectral crossings, and optional overlap matrices, validating shapes before memoized computations populate caches.【F:Willow lab setup.txt†L324-L512】

--- a/MODULE_TRICKS.md
+++ b/MODULE_TRICKS.md
@@ -1,0 +1,19 @@
+# Willow Lab Module Integration & Operational Tricks
+
+## Project skeleton and environment
+- Standardize on a reproducible Conda stack (Python 3.11 plus NumPy, SciPy, pandas, h5py, numba, PyYAML, Matplotlib, NetworkX, pytest) and organize the repository so ingestion, caching, Trinity analysis, tests, geometry, T¹⁴ logic, and CLI live in predictable modules under `willowlab/` with YAML configs for orchestration.【F:Willow lab setup.txt†L205-L324】
+
+## Schema-driven ingestion core
+- The immutable `WillowDataset` dataclass unifies JT scan points, Floquet eigen-data, resolvent traces, entropy, η oscillations, Chern parity, spectral crossings, and optional overlap matrices, validating shapes before memoized computations populate caches.【F:Willow lab setup.txt†L324-L512】
+
+## Trinity and test orchestration
+- The CLI loader hydrates a Willow bundle, runs the Step-1 Trinity invariants (`WillowTrinityStep1.compute_all`) with configurable JT anchor and window, conditionally executes Spectral duality, η-lock, and geometry batteries when data is present, and records JSON summaries to an artifacts directory.【F:Willow lab setup.txt†L1600-L1718】
+
+## Zip-to-Willow conveyor
+- Stage A triage inspects zip members by magic bytes, records a manifest, and opportunistically lifts JT grids or eigenpairs, while Stage B extractors reconcile partial payloads into complete Willow bundles before normalization and persistence to hashed `.npz`/`.h5` artifacts with provenance manifests.【F:Willow lab Injest.txt†L1-L200】【F:Willow lab Injest.txt†L520-L678】
+
+## Incremental caching and HDF5 probing
+- `DirCache` tracks size/mtime and SHA256 digests per ingestion root to skip unchanged files, and the one-level HDF5 walker samples root and child groups within memory budgets so foreign layouts still surface key tensors.【F:Willow lab Helpers.txt†L1-L520】
+
+## Eigenpair reconciliation and CLI ergonomics
+- Merge policy helpers derive eigenpairs from operators when needed, resolve conflicts across supplied data, and expose an `--merge-policy` flag (`auto`, `prefer_operator`, `prefer_supplied`) alongside `--cache-root` so the assembly CLI can steer conflicts and reuse cached results; usage recipes show first-run and incremental invocations plus guardrails for cache validity and walker budgets.【F:Willow lab Helpers.txt†L720-L1760】

--- a/TALKING_POINTS.md
+++ b/TALKING_POINTS.md
@@ -1,0 +1,14 @@
+# Willow Lab Talking Points, References, and Miscellany
+
+## Source references cited in the PDFs
+- Robust validation playbook references (`Robust validation.pdf`) anchor the Step-1 Trinity invariants design.【F:Willow lab setup.txt†L69-L72】
+- Group-theory dossiers (`Group 1.pdf` and `Group 2.pdf`) back the Spectral↔Entanglement, η-lock, and topology synthesis batteries.【F:Willow lab setup.txt†L100-L126】
+
+## Presentation-ready highlights
+- Lead with the unified pitch: normalize every dataset into the Willow schema, push it through the Trinity analyzer for cancellation-safe resolvent features and EP diagnostics, then run the Spectral, η-lock, and Wilson/residue batteries to ship reproducible topology reports from one API.【F:Willow lab setup.txt†L205-L244】
+- Showcase the production-grade invariants, residue atlas, non-Abelian Wilson loops, and c₁₄ estimator as provenance glints the team can point to during talks.【F:Willow lab ext 1.txt†L1533-L1568】
+- Close with the scaling playbook for parameter cartography—truncate to top residues, use FFT-Poisson solves for p=2 grids, or tile with halos—to reassure stakeholders about throughput on large scans.【F:Willow lab ext 1.txt†L1570-L1628】
+
+## Usage reminders and follow-ups
+- Minimal code snippet: load a Willow NPZ, run `WillowTrinityStep1.compute_all()`, and attach Spectral duality checks when entropy and energy data are present for quick reporting.【F:Willow lab setup.txt†L1914-L1956】
+- Offer to mint an example NPZ from prior Floquet runs, execute all three batteries, and iterate thresholds against the hardware noise floor before expanding into full cartography scans.【F:Willow lab setup.txt†L1957-L2005】


### PR DESCRIPTION
## Summary
- compile mathematical constructs from the Willow Lab PDFs into `MATH_COMPILATION.md`
- document ingestion and module-integration practices in `MODULE_TRICKS.md`
- capture presentation talking points and references in `TALKING_POINTS.md`

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e05de6a278832cb18c3aabbb2fbb2e