### PR TITLE
Add CLI commands for resolvent, spectral flow, and disorder analyses

### DIFF
--- a/willowlab/cli.py
+++ b/willowlab/cli.py
@@ -113,7 +113,7 @@ def run_spectral_flow(config_path):
         return
 
     # Extract closed loop from eigenvectors
-    evecs_loop = [ds.floquet_eigenvectors[t] for t in range(len(ds.JT_scan_points))]
+    evecs_loop = list(ds.floquet_eigenvectors)
     evecs_loop.append(evecs_loop[0])  # Close loop
 
     # Compute Berry phases


### PR DESCRIPTION
## Summary
- extend the CLI module with runners for resolvent, spectral-flow, and disorder analyses
- emit JSON artifacts for each analysis, including theorem validation when data is present
- add a command dispatcher for the new analyses alongside the existing trinity workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23c157f40832cbafc185570d26bf4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands for resolvent analysis that save results to JSON and optionally run validation when entropy data is available.
  * Added a spectral-flow analysis command that outputs JSON, computes the Chern number, and optionally runs validation when η data is present.
  * Added a disorder sharpening command that outputs JSON and reports the optimal delta and enhancement factor.
  * Existing commands and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->