### PR TITLE
Fix package-relative imports for WillowDataset usage

### DIFF
--- a/willowlab/io.py
+++ b/willowlab/io.py
@@ -1,5 +1,6 @@
-import numpy as np, h5py, json, pathlib
-from schema import WillowDataset
+import numpy as np, h5py, pathlib
+
+from .schema import WillowDataset
 
 def load_willow(path, *, kind=None, meta=None) -> WillowDataset:
     """

--- a/willowlab/trinity.py
+++ b/willowlab/trinity.py
@@ -1,5 +1,6 @@
 import numpy as np
-from schema import WillowDataset
+
+from .schema import WillowDataset
 
 #--- tiny epsilon + helpers (per your spec) ---
 _EPS = 1e-18


### PR DESCRIPTION
## Summary
- fix WillowDataset imports in io and trinity modules to use package-relative paths
- remove unused json import from the io module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e26d8095bc832cb97d4635c84514cb