### PR TITLE
Surface Nobel dataset load failures

### DIFF
--- a/willowlab/cli.py
+++ b/willowlab/cli.py
@@ -221,6 +221,9 @@ def run_nobel_validation_cli(report_path: str = "nobel_validation_report.json"):
     except AssertionError as exc:
         print(f"❌ VALIDATION FAILED: {exc}")
         return
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(f"❌ VALIDATION ABORTED: {exc}")
+        return
 
     print("✅ VALIDATION COMPLETE")
     print(f"Report saved: {pathlib.Path(report_path).resolve()}")

--- a/willowlab/tests/t_nobel_validation.py
+++ b/willowlab/tests/t_nobel_validation.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import cmath
 import json
 import math
+import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 from typing import Dict, List
 
 from willowlab.schema import (
@@ -222,21 +226,31 @@ def _synthetic_dataset() -> WillowDataset:
 
 
 def _load_default_datasets() -> Dict[str, WillowDataset]:
-    try:
-        from willowlab.io import load_willow
+    from willowlab.io import load_willow
 
+    try:
         sept = load_willow("willow_sept_2025.npz")
         pooled = load_willow("willow_pooled_2025.npz")
         return {"sept_2025": sept, "sept_dec_2025": pooled}
-    except Exception:  # pragma: no cover - fall back to synthetic data
-        synthetic = _synthetic_dataset()
-        return {"sept_2025": synthetic, "sept_dec_2025": synthetic}
+    except FileNotFoundError as exc:  # pragma: no cover - depends on filesystem
+        raise FileNotFoundError(
+            "Missing required Nobel validation dataset: "
+            "willow_sept_2025.npz"
+        ) from exc
+    except Exception as exc:  # pragma: no cover - depends on file integrity
+        raise RuntimeError(
+            "Failed to load default Nobel validation datasets. "
+            "Ensure willow_sept_2025.npz and willow_pooled_2025.npz are valid."
+        ) from exc
 
 
-def execute_nobel_validation(report_path: Path | str = "nobel_validation_report.json") -> Dict[str, object]:
-    datasets = _load_default_datasets()
+def execute_nobel_validation(
+    report_path: Path | str = "nobel_validation_report.json",
+    datasets: Dict[str, WillowDataset] | None = None,
+) -> Dict[str, object]:
+    dataset_map = datasets if datasets is not None else _load_default_datasets()
     runner = NobelValidationRunner()
-    suite = runner.run_complete_validation(datasets)
+    suite = runner.run_complete_validation(dataset_map)
     report = suite.generate_nobel_report()
 
     path = Path(report_path)
@@ -248,7 +262,29 @@ def test_nobel_validation(tmp_path):
     """Exercise the Nobel validation runner on synthetic datasets."""
 
     report_path = tmp_path / "nobel_validation_report.json"
-    report = execute_nobel_validation(report_path)
+    synthetic = _synthetic_dataset()
+    datasets = {"sept_2025": synthetic, "sept_dec_2025": synthetic}
+    report = execute_nobel_validation(report_path, datasets=datasets)
 
     assert report["theorems_tested"] == 2
     assert report_path.exists()
+
+
+def test_load_default_datasets_missing(monkeypatch):
+    def fake_load(path):
+        raise FileNotFoundError("not found")
+
+    monkeypatch.setitem(sys.modules, "willowlab.io", SimpleNamespace(load_willow=fake_load))
+
+    with pytest.raises(FileNotFoundError):
+        _load_default_datasets()
+
+
+def test_load_default_datasets_corrupted(monkeypatch):
+    def fake_load(path):
+        raise ValueError("bad data")
+
+    monkeypatch.setitem(sys.modules, "willowlab.io", SimpleNamespace(load_willow=fake_load))
+
+    with pytest.raises(RuntimeError):
+        _load_default_datasets()


### PR DESCRIPTION
## Summary
- raise explicit errors when the Nobel validation datasets are missing or corrupted
- allow the validation runner to accept injected datasets so tests use synthetic data
- update the CLI messaging and add tests covering the new failure handling

## Testing
- pytest willowlab/tests/t_nobel_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68e466f352b8832cac24688768abc940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced Nobel validation CLI with clearer error handling: displays “VALIDATION ABORTED” and exits cleanly when datasets are missing or invalid.
- Bug Fixes
  - Prevents unhandled errors during validation by gracefully catching missing files and runtime failures, improving reliability and user feedback.
- Tests
  - Added tests covering missing and corrupted default datasets to ensure proper exceptions and messages.
  - Enabled injection of synthetic datasets in tests to validate custom dataset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->